### PR TITLE
[FEAT] Add Statistics Model and Tests

### DIFF
--- a/contract/src/lib.cairo
+++ b/contract/src/lib.cairo
@@ -4,10 +4,12 @@ pub mod systems {
 
 pub mod models {
     pub mod character;
+    pub mod statistics;
 }
 
 #[cfg(test)]
 pub mod tests {
     // mod test_world;
     mod test_character;
+    mod test_statistics;
 }

--- a/contract/src/models/statistics.cairo
+++ b/contract/src/models/statistics.cairo
@@ -1,0 +1,49 @@
+#[derive(Copy, Drop, Serde)]
+#[dojo::model]
+pub struct Statistics {
+    #[key]
+    pub player_id: felt252,
+    pub matches_played: u8,
+    pub wins: u8,
+    pub defeats: u8,
+}
+
+pub fn initialize_statistics(player_id: felt252) -> Statistics {
+    Statistics {
+        player_id,
+        matches_played: 0,
+        wins: 0,
+        defeats: 0,
+    }
+}
+
+pub trait StatisticsTrait<T> {
+    fn increment_matches_played(ref self: T);
+    fn increment_wins(ref self: T);
+    fn increment_defeats(ref self: T);
+    fn get_win_rate(self: @T) -> felt252;
+}
+
+pub impl StatisticsImpl of StatisticsTrait<Statistics> {
+    fn increment_matches_played(ref self: Statistics) {
+        self.matches_played += 1;
+    }
+
+    fn increment_wins(ref self: Statistics) {
+        self.wins += 1;
+    }
+
+    fn increment_defeats(ref self: Statistics) {
+        self.defeats += 1;
+    }
+
+    fn get_win_rate(self: @Statistics) -> felt252 {
+        if (*self.matches_played == 0) {
+            return 0;
+        }
+
+        let win_rate = (*self.wins) * 100 / (*self.matches_played);
+        
+        win_rate.into()
+    }
+}

--- a/contract/src/tests/test_statistics.cairo
+++ b/contract/src/tests/test_statistics.cairo
@@ -1,0 +1,65 @@
+use stark_brawl::models::statistics::*;
+
+fn init_default() -> Statistics {
+    let player_id = 1;
+    let stats = initialize_statistics(player_id);
+
+    assert(stats.player_id == player_id, 'Player ID should match');
+    assert(stats.matches_played == 0, 'Matches played should be 0');
+    assert(stats.wins == 0, 'Wins should be 0');
+    assert(stats.defeats == 0, 'Defeats should be 0');
+    
+    return stats;
+}
+
+#[test]
+fn test_initialize_statistics() {
+    // Discard the return value with _ as we only verify that the initialization works correctly
+    let _ = init_default();
+}
+
+#[test]
+fn test_increment_matches_played() {
+    let mut stats = init_default();
+    stats.increment_matches_played();
+    assert(stats.matches_played == 1, 'Matches played should be 1');
+}
+
+#[test]
+fn test_increment_wins() {
+    let mut stats = init_default();
+    stats.increment_wins();
+    assert(stats.wins == 1, 'Wins should be 1');
+}
+
+#[test]
+fn test_increment_defeats() {
+    let mut stats = init_default();
+    stats.increment_defeats();
+    assert(stats.defeats == 1, 'Defeats should be 1');
+}
+
+#[test]
+fn test_get_win_rate() {
+    let mut stats = init_default();
+    
+    // Case 1: 1 match, 1 win -> 100%
+    stats.increment_matches_played();
+    stats.increment_wins();
+    assert(stats.get_win_rate() == 100, 'Win rate should be 100%');
+
+    // Case 2: 2 matches, 1 win -> 50%
+    stats.increment_matches_played();
+    assert(stats.get_win_rate() == 50, 'Win rate should be 50%');
+
+    // Case 3: 3 matches, 1 win -> 33%
+    stats.increment_matches_played();
+    stats.increment_defeats();
+    assert(stats.get_win_rate() == 33, 'Win rate should be 33%');
+}
+
+#[test]
+fn test_win_rate_with_zero_matches() {
+    let stats = init_default();
+    assert(stats.get_win_rate() == 0, 'Win rate should be 0%');
+}


### PR DESCRIPTION
# Summary of Changes for PR

Closes: #8 

- Implemented the Statistics model in `contract/src/models/statistics.cairo`
- Added the following attributes to the model: player_id, matches_played, wins, defeats
- Implemented core functionality with initialize_statistics(), increment methods, and get_win_rate()
- Created comprehensive test suite in `contract/src/tests/test_statistics.cairo` to verify all functionality
- Added safeguards against division by zero in win rate calculation
- Maintained consistent structure and style with existing models in the codebase
- Implemented percentage calculation for win rate that properly handles edge cases

All acceptance criteria have been met, with statistics initialized to 0, increment methods working as expected, and win rate calculation returning accurate percentages in all test scenarios.

<img width="898" alt="Screenshot 2025-02-28 at 16 36 48" src="https://github.com/user-attachments/assets/389b00a5-55b6-45ff-a662-97029f531996" />

