### PR TITLE
feat: add tower stats and store

### DIFF
--- a/contract/src/lib.cairo
+++ b/contract/src/lib.cairo
@@ -19,10 +19,13 @@ pub mod models {
     pub mod coins;
     pub mod gems;
     pub mod trap;
+    pub mod tower_stats;
     pub mod tower; 
     pub mod enemy;
     pub mod projectile;
 }
+
+mod store;
 
 #[cfg(test)]
 pub mod tests {

--- a/contract/src/models/tower_stats.cairo
+++ b/contract/src/models/tower_stats.cairo
@@ -1,0 +1,18 @@
+#[derive(Copy, Drop, Serde, Debug, PartialEq)]
+#[dojo::model]
+pub struct TowerStats {
+    #[key]
+    pub tower_type: felt252,
+    #[key]
+    pub level: u8,
+    pub range: u8,
+    pub fire_rate: u8,
+    pub damage: u32,
+}
+
+#[generate_trait]
+pub impl TowerStatsImpl of TowerStatsTrait {
+    fn new(tower_type: felt252, level: u8, range: u8, fire_rate: u8, damage: u32) -> TowerStats {
+        TowerStats { tower_type, level, range, fire_rate, damage }
+    }
+}

--- a/contract/src/store.cairo
+++ b/contract/src/store.cairo
@@ -1,0 +1,27 @@
+use dojo::world::WorldStorage;
+use dojo::model::ModelStorage;
+use stark_brawl::models::tower_stats::TowerStats;
+
+#[derive(Drop)]
+struct Store {
+    world: WorldStorage
+}
+
+#[generate_trait]
+impl StoreImpl of StoreTrait {
+    #[inline(always)]
+    fn new(world: WorldStorage) -> Store {
+        Store { world: world }
+    }
+
+    #[inline]
+    fn get_tower_stats(self: Store, tower_type: felt252, level: u8) -> TowerStats {
+        self.world.read_model((tower_type, level))
+    }
+
+    #[inline]
+    fn set_tower_stats(ref self: Store, tower_stats: TowerStats) {
+        self.world.write_model(@tower_stats);
+    }
+
+}


### PR DESCRIPTION
Closes https://github.com/SunsetLabs-Game/Stark-Brawl/issues/105

Was unable to create test since we will need to setup a proper test suite with mocked systems because the tower_stats will be saved and retrieved from the world (similar to what you can see here https://github.com/dojoengine/dojo-starter/blob/main/src/tests/test_world.cairo). 
I tried to do so (setup tests) but seems like the brawl_system is broken, so it will require too much extra work not specified in the ticket.

So, maybe you can create separate stories, one for **fixing the brawl game** and other to **setup proper test suite** with dojo_cairo_test utils for mocking the world and contracts call. 