### PR TITLE
feat: implement Enemy_Path model

### DIFF
--- a/contract/src/lib.cairo
+++ b/contract/src/lib.cairo
@@ -23,6 +23,7 @@ pub mod models {
     pub mod tower; 
     pub mod enemy;
     pub mod projectile;
+    pub mod enemy_path;
 }
 
 mod store;

--- a/contract/src/models/enemy_path.cairo
+++ b/contract/src/models/enemy_path.cairo
@@ -1,0 +1,101 @@
+#[derive(Drop, Destruct)]
+pub struct EnemyPath {
+    pub path_id: u64,
+    pub length: u32,
+}
+
+#[derive(Drop, Destruct, Copy)]
+pub struct EnemyPathStep {
+    pub x: u32,
+    pub y: u32,
+}
+
+mod errors {
+    pub const IndexOutOfBounds: felt252 = 'IndexOutOfBounds';
+    pub const MismatchedLengths: felt252 = 'MismatchedLengths';
+}
+
+#[generate_trait]
+pub trait EnemyPathSystem {
+    fn new(path_id: u64, xs: Array<u32>, ys: Array<u32>) -> EnemyPath;
+    fn get_step(xs: Array<u32>, ys: Array<u32>, index: u32) -> EnemyPathStep;
+    fn length(path: EnemyPath) -> u32;
+}
+
+impl EnemyPathImpl of EnemyPathSystem {
+    fn new(path_id: u64, xs: Array<u32>, ys: Array<u32>) -> EnemyPath {
+        assert(xs.len() == ys.len(), errors::MismatchedLengths);
+        EnemyPath { path_id, length: xs.len().into() }
+    }
+
+    fn get_step(xs: Array<u32>, ys: Array<u32>, index: u32) -> EnemyPathStep {
+        assert(index < xs.len(), errors::IndexOutOfBounds);
+        let idx: usize = index.into();
+        EnemyPathStep {
+            x: *xs.at(idx),
+            y: *ys.at(idx),
+        }
+    }
+
+    fn length(path: EnemyPath) -> u32 {
+        path.length
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+
+    #[test]
+    fn test_path_creation_and_access() {
+        let mut xs = ArrayTrait::new();
+        let mut ys = ArrayTrait::new();
+        xs.append(10_u32);
+        xs.append(20_u32);
+        xs.append(30_u32);
+        ys.append(1_u32);
+        ys.append(2_u32);
+        ys.append(3_u32);
+
+        let path = EnemyPathImpl::new(5_u64, xs.clone(), ys.clone());
+        assert(path.length == 3_u32, 'Incorrect length');
+
+        let step0 = EnemyPathImpl::get_step(xs.clone(), ys.clone(), 0_u32);
+        assert(step0.x == 10_u32, 'Step 0 x mismatch');
+        assert(step0.y == 1_u32, 'Step 0 y mismatch');
+
+        let step2 = EnemyPathImpl::get_step(xs.clone(), ys.clone(), 2_u32);
+        assert(step2.x == 30_u32, 'Step 2 x mismatch');
+        assert(step2.y == 3_u32, 'Step 2 y mismatch');
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_step_access_out_of_bounds_panics() {
+        let mut xs = ArrayTrait::new();
+        let mut ys = ArrayTrait::new();
+        xs.append(10_u32);
+        ys.append(1_u32);
+        let _ = EnemyPathImpl::get_step(xs, ys, 1_u32); //Only index 0 is valid
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_mismatched_lengths_panics() {
+        let mut xs = ArrayTrait::new();
+        let mut ys = ArrayTrait::new();
+        xs.append(10_u32);
+        //ys is empty
+        let _ = EnemyPathImpl::new(1_u64, xs, ys);
+    }
+
+    #[test]
+    fn test_zero_length_path() {
+        let xs = ArrayTrait::new();
+        let ys = ArrayTrait::new();
+        let path = EnemyPathImpl::new(42_u64, xs.clone(), ys.clone());
+        assert(path.length == 0_u32, 'ZeroLen');
+    }
+
+}


### PR DESCRIPTION
### 🚀 **Feature: Implement `EnemyPath` Model in Cairo**  
Closes #106

---

### 📋 Description
This PR adds a new **EnemyPath** model in Cairo, defining how enemies traverse the map along fixed coordinate sequences. Each path has:
- a unique `path_id`  
- a recorded `length` (number of steps)  
- per‐step `(x, y)` coordinates stored externally

The implementation validates matching array lengths, provides index‐based lookup of each step, and includes unit tests for correct behavior and out-of-bounds checks.

---

### ✅ Acceptance Criteria
- [x] Define `EnemyPath` struct with `path_id: u64` and `length: u32`  
- [x] Define `EnemyPathStep` struct with `x: u32`, `y: u32`  
- [x] Implement `EnemyPathSystem` trait:  
  - `new(path_id, xs, ys) → EnemyPath`  
  - `get_step(xs, ys, index) → EnemyPathStep`  
  - `length(path) → u32`  
- [x] Add unit tests for:  
  - basic path creation & step-by-step access  
  - panicking on out-of-bounds access
  - panicking on mismatched lenght path
  - panicking on zero lenght path   

---

### 🛠 Changes Implemented

- **`src/models/enemy_path.cairo`**  
  - Added `EnemyPath` and `EnemyPathStep` structs  
  - Defined `errors::{MismatchedLengths, IndexOutOfBounds}`  
  - Generated `EnemyPathSystem` trait & its `EnemyPathImpl` methods:  
    - `new(...)` validates lengths and returns path metadata  
    - `get_step(...)` asserts bounds and returns the `(x,y)` step  
    - `length(...)` returns the stored step count  
  - Wrote four unit tests under `#[cfg(test)]`:  
    1. `test_path_creation_and_access`  
    2. `test_step_access_out_of_bounds_panics`  
    3. `test_mismatched_lengths_panics`
    4. `test_zero_length_path`

- **`src/lib.cairo`**  
  - Exported the new model with:  
    ```cairo
    pub mod models::enemy_path;
    ```

---

### 🧪 Evidence

test stark_brawl::models::enemy_path::tests::test_path_creation_and_access ... ok (gas usage est.: 82420)
test stark_brawl::models::enemy_path::tests::test_step_access_out_of_bounds_panics ... ok (gas usage est.: 4610)
test stark_brawl::models::enemy_path::tests::test_mismatched_lengths_panics ... ok (gas usage est.: 1800)
test stark_brawl::models::enemy_path::tests::test_zero_length_path ... ok (gas usage est.: 11880)


![image](https://github.com/user-attachments/assets/2d5cbc50-28ef-4ad4-93b7-346cde9432b0)

