### PR TITLE
feat: Store: Integrate rewards and player progression after enemy defeat

### DIFF
--- a/contract/src/models/enemy.cairo
+++ b/contract/src/models/enemy.cairo
@@ -13,6 +13,7 @@ pub struct Enemy {
     pub is_alive: bool,
     pub coin_reward: u32,
     pub xp_reward: u32,
+    pub reward_claimed: bool,
 }
 
 mod errors {
@@ -51,7 +52,18 @@ pub impl EnemyImpl of EnemySystem {
         assert(coin_reward > 0_u32, 'coin_reward must be > 0');
         assert(xp_reward > 0_u32, 'xp_reward must be > 0');
 
-        Enemy { id, enemy_type, health, speed, x, y, is_alive: true, coin_reward, xp_reward }
+        Enemy {
+            id,
+            enemy_type,
+            health,
+            speed,
+            x,
+            y,
+            is_alive: true,
+            coin_reward,
+            xp_reward,
+            reward_claimed: false // Initialize as false
+        }
     }
 
     fn take_damage(self: @Enemy, amount: u32) -> Enemy {
@@ -77,6 +89,7 @@ pub impl EnemyImpl of EnemySystem {
             is_alive: new_is_alive,
             coin_reward: *self.coin_reward,
             xp_reward: *self.xp_reward,
+            reward_claimed: *self.reward_claimed // Preserve existing value
         }
     }
 
@@ -95,6 +108,7 @@ pub impl EnemyImpl of EnemySystem {
             is_alive: *self.is_alive,
             coin_reward: *self.coin_reward,
             xp_reward: *self.xp_reward,
+            reward_claimed: *self.reward_claimed,
         }
     }
 }
@@ -111,6 +125,7 @@ pub impl ZeroableEnemy of Zero<Enemy> {
             is_alive: false,
             coin_reward: 0,
             xp_reward: 0,
+            reward_claimed: false,
         }
     }
 

--- a/contract/src/models/player.cairo
+++ b/contract/src/models/player.cairo
@@ -2,7 +2,7 @@ use starknet::{ContractAddress, contract_address_const};
 use core::num::traits::zero::Zero;
 use core::option::Option;
 
-#[derive(Copy, Drop, Serde, IntrospectPacked, Debug)]
+#[derive(Copy, Drop, Serde, Debug)]
 #[dojo::model]
 pub struct Player {
     #[key]


### PR DESCRIPTION
### Description

This pull request introduces the core logic for player progression by automatically distributing rewards when an enemy is defeated. This is a crucial feature for the main tower defense gameplay loop, ensuring players are rewarded in real-time for their actions.

The system is designed to be robust and prevent exploits by ensuring rewards for a single enemy can only be claimed once.

### Key Changes

*   **`models/enemy.cairo`**:
    *   Extended the `Enemy` model with a `reward_claimed: bool` flag. This stateful field is critical for preventing duplicate reward claims.

*   **`store.cairo`**:
    *   Added a new `distribute_rewards` function responsible for the core reward logic. This function atomically:
        1.  Verifies the enemy `is_alive == false`.
        2.  Asserts that `reward_claimed == false`.
        3.  Adds the `coin_reward` and `xp_reward` to the player's stats.
        4.  Updates the enemy's `reward_claimed` flag to `true`.
        5.  Writes both the updated `Player` and `Enemy` models back to storage.

*   **`systems/game.cairo`**:
    *   Introduced an `attack_enemy` function to serve as the trigger point for this system.
    *   This function calls `store.distribute_rewards` immediately after an enemy's health is reduced to zero, seamlessly integrating the reward system into the gameplay loop.

### Tests

*   **`tests/test_store.cairo`**:
    *   Added a comprehensive test suite for the reward distribution logic, covering:
        *   Successful reward claims and correct stat updates.
        *   Rejection of claims for living enemies.
        *   **Prevention of double-claiming rewards for the same enemy.**
        *   Correct handling of multiple players and enemies to ensure state isolation.

**Closes:** #162 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added an attack enemy action that applies damage and, upon defeat, automatically distributes coin and XP rewards to the attacker.
  * Introduced reward-claimed tracking to prevent double-claiming rewards from the same enemy.
  * Ensures rewards can only be claimed if the enemy is defeated; attempts otherwise will fail with a clear error.

* Tests
  * Added comprehensive reward distribution tests, covering successful claims, prevention of double claims, enemy-alive rejections, zero-initial stats, and multi-player/multi-enemy scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->